### PR TITLE
Bump NoMachine to 9.4.14, simplify download logic, and rewrite README for podman usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,20 +22,18 @@ RUN mkdir -p /var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id && mkdir -
 RUN sed -i 's/SELINUX=permissive/SELINUX=disabled/g' /etc/selinux/config
 
 # Install NoMachine
-ARG NOMACHINE_AMD64_RPM="nomachine_9.2.18_3_x86_64.rpm"
-ARG NOMACHINE_ARM64_RPM="nomachine_9.2.18_3_aarch64.rpm"
-ARG NOMACHINE_URL_AMD64="https://web9001.nomachine.com/download/9.2/Linux/${NOMACHINE_AMD64_RPM}"
-ARG NOMACHINE_URL_ARM64="https://web9001.nomachine.com/download/9.2/Arm/${NOMACHINE_ARM64_RPM}"
+ARG NOMACHINE_AMD64_RPM="nomachine_9.4.14_1_x86_64.rpm"
+ARG NOMACHINE_ARM64_RPM="nomachine_9.4.14_1_aarch64.rpm"
+ARG NOMACHINE_URL_AMD64="https://web9001.nomachine.com/download/9.4/Linux/${NOMACHINE_AMD64_RPM}"
+ARG NOMACHINE_URL_ARM64="https://web9001.nomachine.com/download/9.4/Arm/${NOMACHINE_ARM64_RPM}"
 
 RUN echo "$NOMACHINE_AMD64_RPM" && \
     echo "$NOMACHINE_URL_AMD64" && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
-        NOMACHINE_VERSION=$(echo "$NOMACHINE_AMD64_RPM" | sed -n 's/nomachine_\([0-9]*\.[0-9]*\)\..*/\1/p'); \
-        curl -fSL "https://download.nomachine.com/download/$NOMACHINE_VERSION/Linux/${NOMACHINE_AMD64_RPM}" -o nomachine.rpm; \
+        curl -fSL "$NOMACHINE_URL_AMD64" -o nomachine.rpm; \
     elif [ "$ARCH" = "aarch64" ]; then \
-        NOMACHINE_VERSION=$(echo "$NOMACHINE_ARM64_RPM" | sed -n 's/nomachine_\([0-9]*\.[0-9]*\)\..*/\1/p'); \
-        curl -fSL "https://download.nomachine.com/download/$NOMACHINE_VERSION/Arm/${NOMACHINE_ARM64_RPM}" -o nomachine.rpm; \
+        curl -fSL "$NOMACHINE_URL_ARM64" -o nomachine.rpm; \
     else \
         echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \

--- a/readme.md
+++ b/readme.md
@@ -1,43 +1,59 @@
-# Container alternative to Virtual Machines for Transient Environments That Require GUI's
+# Container Alternative to Virtual Machines for Transient GUI Environments
 
-A Fedora based Container/Docker image with Xfce and NoMachine which allows for local Virtual Machine equivalent graphical performance (as opposed to X11, VNC and RDP), accessing the desktop environment.
+A Fedora-based container image with Xfce and NoMachine that provides local virtual-machine-like graphical performance (as opposed to X11, VNC, and RDP) for accessing a full desktop environment.
 
-### Inspiration from
+## Inspiration
 
-[docker-fedora-xfce-nomachine](https://github.com/cmanique/docker-fedora-xfce-nomachine) 
+- [docker-fedora-xfce-nomachine](https://github.com/cmanique/docker-fedora-xfce-nomachine)
+- [Docker as an Alternative to Virtual Machines for Transient Environments That Require a GUI](https://dev.to/cmanique/docker-as-an-alternative-to-virtual-machines-for-transient-environments-that-require-a-gui-24la)
 
-[Docker as an Alternative to Virtual Machines for Transient Environments That Require a GUI](https://dev.to/cmanique/docker-as-an-alternative-to-virtual-machines-for-transient-environments-that-require-a-gui-24la)
+## Quick notes
 
-## How use
+- This repository is documented for **podman-only workflows**.
+- All command examples below use `podman` directly.
+- If you previously used a `docker` alias, replace it with `podman` commands.
 
-### a) Build the image from this repository
+## Usage
 
-```
-$ git clone https://github.com/nilsl88/container-fedora-xfce-nomachine.git
-$ cd container-fedora-xfce-nomachine
-$ alias docker=podman
-$ docker build -t fedora-xfce-nomachine .
-```   
+### 1) 🛠️ Build the image from this repository
 
-### b) Directly from Docker Hub
-
-```
-$ alias docker=podman
-$ docker pull docker.io/lundberg88/fedora-xfce-nomachine:<tag>
+```bash
+git clone https://github.com/nilsl88/container-fedora-xfce-nomachine.git
+cd container-fedora-xfce-nomachine
+podman build -t fedora-xfce-nomachine .
 ```
 
-### Start a container
+If you want to build for both CPU architectures (`amd64` + `arm64`) and publish a multi-arch manifest:
 
-```
-$ alias docker=podman
-$ docker run --privileged -d -p 4000:4000 -p 4000:4000/udp --name fedora-xfce-nomachine docker.io/lundberg88/fedora-xfce-nomachine:<tag>
+```bash
+export IMAGE=docker.io/lundberg88/fedora-xfce-nomachine:<tag>
+podman build \
+  --platform linux/amd64,linux/arm64 \
+  --manifest $IMAGE \
+  .
+podman manifest push --all $IMAGE docker://$IMAGE
 ```
 
-### Stop the container
+### 2) 📥 Pull directly from Docker Hub
 
+```bash
+podman pull docker.io/lundberg88/fedora-xfce-nomachine:<tag>
 ```
-$ alias docker=podman
-$ docker stop fedora-xfce-nomachine
-# Or stop and remove 
-$ docker rm -f fedora-xfce-nomachine
+
+### 3) 🚀 Start a container
+
+```bash
+podman run --privileged -d -p 4000:4000 -p 4000:4000/udp --name fedora-xfce-nomachine docker.io/lundberg88/fedora-xfce-nomachine:<tag>
 ```
+
+### 4) 🛑 Stop and remove the container
+
+```bash
+podman stop fedora-xfce-nomachine
+# Optional: stop and remove
+podman rm -f fedora-xfce-nomachine
+```
+
+## Access
+
+After the container starts, connect with NoMachine to your host on port `4000`.


### PR DESCRIPTION
### Motivation
- Update the NoMachine installer to a current release and simplify the Dockerfile download logic to use explicit URL args instead of parsing versions, and clarify repository usage by documenting a podman-first workflow and multi-arch build/publish steps.

### Description
- Bumped `NOMACHINE_AMD64_RPM` and `NOMACHINE_ARM64_RPM` to `nomachine_9.4.14_1_*` and updated `NOMACHINE_URL_AMD64` and `NOMACHINE_URL_ARM64` accordingly in the `Dockerfile`.
- Replaced in-Dockerfile version extraction and manual `download.nomachine.com` construction with direct `NOMACHINE_URL_*` curl downloads for each architecture.
- Cleaned up the README by rewriting the introduction, adding podman-focused usage instructions, providing build/pull/run/stop examples, and including a multi-arch manifest build/push example.
- Minor formatting and wording improvements across the README for clarity and consistency.

### Testing
- Performed a local smoke build using `podman build -t fedora-xfce-nomachine .` which completed successfully.
- No automated test suite changes were introduced in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1166556348331a8b9a39a3a2b39a8)